### PR TITLE
Propagate Peer 'error' event up from Pool

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -86,7 +86,7 @@ Pool.MaxConnectedPeers = 8;
 Pool.RetrySeconds = 30;
 Pool.PeerEvents = ['version', 'inv', 'getdata', 'ping', 'ping', 'addr',
   'getaddr', 'verack', 'reject', 'alert', 'headers', 'block',
-  'tx', 'getblocks', 'getheaders'
+  'tx', 'getblocks', 'getheaders', 'error'
 ];
 
 


### PR DESCRIPTION
It seems this is useful to be able to catch when using `Pool` rather than `Peer` directly.