### PR TITLE
Fix pong type in Pool Events list?

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -84,7 +84,7 @@ util.inherits(Pool, EventEmitter);
 
 Pool.MaxConnectedPeers = 8;
 Pool.RetrySeconds = 30;
-Pool.PeerEvents = ['version', 'inv', 'getdata', 'ping', 'ping', 'addr',
+Pool.PeerEvents = ['version', 'inv', 'getdata', 'ping', 'pong', 'addr',
   'getaddr', 'verack', 'reject', 'alert', 'headers', 'block',
   'tx', 'getblocks', 'getheaders', 'error'
 ];


### PR DESCRIPTION
Another simple one.  I think this was supposed to be `pong`, since `pong` isn't in the list, and `ping` is there twice.