### PR TITLE
Add 'peerconnect' event from Pool

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -169,6 +169,9 @@ Pool.prototype._connectPeer = function _connectPeer(addr) {
     peer.on('disconnect', function peerDisconnect() {
       self.emit('peerdisconnect', peer, addr);
     });
+    peer.on('connect', function peerConnect() {
+      self.emit('peerconnect', peer, addr);
+    });
     peer.on('ready', function peerReady() {
       self.emit('peerready', peer, addr);
     });


### PR DESCRIPTION
This could be useful to some consumers.  I'm using it to detect nodes that are connected, but slow to respond with their `verack` commands, to disconnect these slow nodes and get different nodes in my pool.