### PR TITLE
Make sure _connectedPeer exists before checking it

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -168,7 +168,8 @@ Pool.prototype._fillConnections = function _fillConnections() {
  * @param {Object} addr - An addr from the list of addrs
  */
 Pool.prototype._removeConnectedPeer = function _removeConnectedPeer(addr) {
-  if (this._connectedPeers[addr.hash].status !== Peer.STATUS.DISCONNECTED) {
+  if (this._connectedPeers[addr.hash] &&
+      this._connectedPeers[addr.hash].status !== Peer.STATUS.DISCONNECTED) {
     this._connectedPeers[addr.hash].disconnect();
   } else {
     delete this._connectedPeers[addr.hash];


### PR DESCRIPTION
I'm not entirely sure this is the right solution, but I've gotten this error working on my SPV client.

I set a timeout to `peer.disconnect()` a peer if I don't receive a `verack` message within 3 seconds, to weed out slow peers from my pool (not sure if that's a good approach or not), but when I call the `peer.disconnect()` on the timeout, it seems to bubble up to this.  My change alleviates that problem, but not sure it's the correct fix or not as I haven't traced through what exactly is going on yet.

```
/Users/throughnothing/Projects/bitcoin/bitcore-spv/node_modules/bitcore-p2p/lib/pool.js:171
  if (this._connectedPeers[addr.hash].status !== Peer.STATUS.DISCONNECTED) {
                                     ^
TypeError: Cannot read property 'status' of undefined
    at Pool._removeConnectedPeer (/Users/throughnothing/Projects/bitcoin/bitcore-spv/node_modules/bitcore-p2p/lib/pool.js:171:38)
    at Pool.peerDisconnectEvent (/Users/throughnothing/Projects/bitcoin/bitcore-spv/node_modules/bitcore-p2p/lib/pool.js:93:10)
    at Pool.emit (events.js:129:20)
    at Peer.peerDisconnect (/Users/throughnothing/Projects/bitcoin/bitcore-spv/node_modules/bitcore-p2p/lib/pool.js:191:12)
    at Peer.emit (events.js:104:17)
    at Peer.disconnect (/Users/throughnothing/Projects/bitcoin/bitcore-spv/node_modules/bitcore-p2p/lib/peer.js:148:8)
    at null._onTimeout (/Users/throughnothing/Projects/bitcoin/bitcore-spv/lib/pool.js:94:10)
    at Timer.listOnTimeout (timers.js:110:15)
```