### PR TITLE
Fix Browserify support

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,6 +3,6 @@
 var gulp = require('gulp');
 var bitcoreTasks = require('bitcore-build');
 
-bitcoreTasks('p2p', {skipBrowser: true});
+bitcoreTasks('p2p');
 
 gulp.task('default', ['lint', 'coverage']);

--- a/lib/messages/builder.js
+++ b/lib/messages/builder.js
@@ -38,35 +38,33 @@ function builder(options) {
       'notfound'
     ],
     commandsMap: {
-      version: 'Version',
-      verack: 'VerAck',
-      ping: 'Ping',
-      pong: 'Pong',
-      block: 'Block',
-      tx: 'Transaction',
-      getdata: 'GetData',
-      headers: 'Headers',
-      notfound: 'NotFound',
-      inv: 'Inventory',
-      addr: 'Addresses',
-      alert: 'Alert',
-      reject: 'Reject',
-      merkleblock: 'MerkleBlock',
-      filterload: 'FilterLoad',
-      filteradd: 'FilterAdd',
-      filterclear: 'FilterClear',
-      getblocks: 'GetBlocks',
-      getheaders: 'GetHeaders',
-      mempool: 'MemPool',
-      getaddr: 'GetAddr'
+      version: require('./commands/version'),
+      verack: require('./commands/verack'),
+      ping: require('./commands/ping'),
+      pong: require('./commands/pong'),
+      block: require('./commands/block'),
+      tx: require('./commands/tx'),
+      getdata: require('./commands/getdata'),
+      headers: require('./commands/headers'),
+      notfound: require('./commands/notfound'),
+      inv: require('./commands/inv'),
+      addr: require('./commands/addr'),
+      alert: require('./commands/alert'),
+      reject: require('./commands/reject'),
+      merkleblock: require('./commands/merkleblock'),
+      filterload: require('./commands/filterload'),
+      filteradd: require('./commands/filteradd'),
+      filterclear: require('./commands/filterclear'),
+      getblocks: require('./commands/getblocks'),
+      getheaders: require('./commands/getheaders'),
+      mempool: require('./commands/mempool'),
+      getaddr: require('./commands/getaddr')
     },
     commands: {}
   };
 
   Object.keys(exported.commandsMap).forEach(function(key) {
-
-    var Command = require('./commands/' + key);
-
+    var Command = exported.commandsMap[key];
     exported.commands[key] = function(obj) {
       return new Command(obj, options);
     };

--- a/lib/messages/commands/addr.js
+++ b/lib/messages/commands/addr.js
@@ -30,6 +30,8 @@ function AddrMessage(arg, options) {
 }
 inherits(AddrMessage, Message);
 
+AddrMessage._name = 'Addresses';
+
 AddrMessage.prototype.setPayload = function(payload) {
   var parser = new BufferReader(payload);
 

--- a/lib/messages/commands/alert.js
+++ b/lib/messages/commands/alert.js
@@ -26,6 +26,8 @@ function AlertMessage(arg, options) {
 }
 inherits(AlertMessage, Message);
 
+AlertMessage._name = 'Alert';
+
 AlertMessage.prototype.setPayload = function(payload) {
   var parser = new BufferReader(payload);
   this.payload = parser.readVarLengthBuffer();

--- a/lib/messages/commands/block.js
+++ b/lib/messages/commands/block.js
@@ -25,6 +25,8 @@ function BlockMessage(arg, options) {
 }
 inherits(BlockMessage, Message);
 
+BlockMessage._name = 'Block';
+
 BlockMessage.prototype.setPayload = function(payload) {
   this.block = this.Block.fromBuffer(payload);
 };

--- a/lib/messages/commands/filteradd.js
+++ b/lib/messages/commands/filteradd.js
@@ -28,6 +28,8 @@ function FilteraddMessage(arg, options) {
 }
 inherits(FilteraddMessage, Message);
 
+FilteraddMessage._name = 'FilterAdd';
+
 FilteraddMessage.prototype.setPayload = function(payload) {
   $.checkArgument(payload);
   var parser = new BufferReader(payload);

--- a/lib/messages/commands/filterclear.js
+++ b/lib/messages/commands/filterclear.js
@@ -16,6 +16,8 @@ function FilterclearMessage(arg, options) {
 }
 inherits(FilterclearMessage, Message);
 
+FilterclearMessage._name = 'FilterClear';
+
 FilterclearMessage.prototype.setPayload = function() {};
 
 FilterclearMessage.prototype.getPayload = function() {

--- a/lib/messages/commands/filterload.js
+++ b/lib/messages/commands/filterload.js
@@ -26,6 +26,8 @@ function FilterloadMessage(arg, options) {
 }
 inherits(FilterloadMessage, Message);
 
+FilterloadMessage._name = 'FilterLoad';
+
 FilterloadMessage.prototype.setPayload = function(payload) {
   this.filter = BloomFilter.fromBuffer(payload);
 };

--- a/lib/messages/commands/getaddr.js
+++ b/lib/messages/commands/getaddr.js
@@ -17,6 +17,8 @@ function GetaddrMessage(arg, options) {
 }
 inherits(GetaddrMessage, Message);
 
+GetaddrMessage._name = 'GetAddr';
+
 GetaddrMessage.prototype.setPayload = function() {};
 
 GetaddrMessage.prototype.getPayload = function() {

--- a/lib/messages/commands/getblocks.js
+++ b/lib/messages/commands/getblocks.js
@@ -32,6 +32,8 @@ function GetblocksMessage(arg, options) {
 }
 inherits(GetblocksMessage, Message);
 
+GetblocksMessage._name = 'GetBlocks';
+
 GetblocksMessage.prototype.setPayload = function(payload) {
   var parser = new BufferReader(payload);
   $.checkArgument(!parser.finished(), 'No data received in payload');

--- a/lib/messages/commands/getdata.js
+++ b/lib/messages/commands/getdata.js
@@ -22,6 +22,8 @@ function GetdataMessage(arg, options) {
 }
 inherits(GetdataMessage, Message);
 
+GetdataMessage._name = 'GetData';
+
 GetdataMessage.prototype.setPayload = function(payload) {
   this.inventory = [];
 

--- a/lib/messages/commands/getheaders.js
+++ b/lib/messages/commands/getheaders.js
@@ -31,6 +31,8 @@ function GetheadersMessage(arg, options) {
 }
 inherits(GetheadersMessage, Message);
 
+GetheadersMessage._name = 'GetHeaders';
+
 GetheadersMessage.prototype.setPayload = function(payload) {
   var parser = new BufferReader(payload);
   $.checkArgument(!parser.finished(), 'No data received in payload');

--- a/lib/messages/commands/headers.js
+++ b/lib/messages/commands/headers.js
@@ -31,6 +31,8 @@ function HeadersMessage(arg, options) {
 }
 inherits(HeadersMessage, Message);
 
+HeadersMessage._name = 'Headers';
+
 HeadersMessage.prototype.setPayload = function(payload) {
   $.checkArgument(payload && payload.length > 0, 'No data found to create Headers message');
   var parser = new BufferReader(payload);

--- a/lib/messages/commands/inv.js
+++ b/lib/messages/commands/inv.js
@@ -23,6 +23,8 @@ function InvMessage(arg, options) {
 }
 inherits(InvMessage, Message);
 
+InvMessage._name = 'Inventory';
+
 InvMessage.prototype.setPayload = function(payload) {
   this.inventory = [];
 

--- a/lib/messages/commands/mempool.js
+++ b/lib/messages/commands/mempool.js
@@ -19,6 +19,8 @@ function MempoolMessage(arg, options) {
 }
 inherits(MempoolMessage, Message);
 
+MempoolMessage._name = 'MemPool';
+
 MempoolMessage.prototype.setPayload = function() {};
 
 MempoolMessage.prototype.getPayload = function() {

--- a/lib/messages/commands/merkleblock.js
+++ b/lib/messages/commands/merkleblock.js
@@ -28,6 +28,8 @@ function MerkleblockMessage(arg, options) {
 }
 inherits(MerkleblockMessage, Message);
 
+MerkleblockMessage._name = 'MerkleBlock';
+
 MerkleblockMessage.prototype.setPayload = function(payload) {
   $.checkArgument(BufferUtil.isBuffer(payload));
   this.merkleBlock = this.MerkleBlock.fromBuffer(payload);

--- a/lib/messages/commands/notfound.js
+++ b/lib/messages/commands/notfound.js
@@ -23,6 +23,8 @@ function NotfoundMessage(arg, options) {
 }
 inherits(NotfoundMessage, Message);
 
+NotfoundMessage._name = 'NotFound';
+
 NotfoundMessage.prototype.setPayload = function(payload) {
   this.inventory = [];
 

--- a/lib/messages/commands/ping.js
+++ b/lib/messages/commands/ping.js
@@ -27,6 +27,8 @@ function PingMessage(arg, options) {
 }
 inherits(PingMessage, Message);
 
+PingMessage._name = 'Ping';
+
 PingMessage.prototype.setPayload = function(payload) {
   var parser = new BufferReader(payload);
   this.nonce = parser.read(8);

--- a/lib/messages/commands/pong.js
+++ b/lib/messages/commands/pong.js
@@ -27,6 +27,8 @@ function PongMessage(arg, options) {
 }
 inherits(PongMessage, Message);
 
+PongMessage._name = 'Pong';
+
 PongMessage.prototype.setPayload = function(payload) {
   var parser = new BufferReader(payload);
   this.nonce = parser.read(8);

--- a/lib/messages/commands/reject.js
+++ b/lib/messages/commands/reject.js
@@ -12,6 +12,8 @@ function RejectMessage(arg, options) {
 }
 inherits(RejectMessage, Message);
 
+RejectMessage._name = 'Reject';
+
 RejectMessage.prototype.setPayload = function() {};
 
 RejectMessage.prototype.getPayload = function() {

--- a/lib/messages/commands/tx.js
+++ b/lib/messages/commands/tx.js
@@ -27,6 +27,8 @@ function TransactionMessage(arg, options) {
 }
 inherits(TransactionMessage, Message);
 
+TransactionMessage._name = 'Transaction';
+
 TransactionMessage.prototype.setPayload = function(payload) {
   if (this.Transaction.prototype.fromBuffer) {
     this.transaction = new this.Transaction().fromBuffer(payload);

--- a/lib/messages/commands/verack.js
+++ b/lib/messages/commands/verack.js
@@ -16,6 +16,8 @@ function VerackMessage(arg, options) {
 }
 inherits(VerackMessage, Message);
 
+VerackMessage._name = 'VerAck';
+
 VerackMessage.prototype.setPayload = function() {};
 
 VerackMessage.prototype.getPayload = function() {

--- a/lib/messages/commands/version.js
+++ b/lib/messages/commands/version.js
@@ -43,6 +43,8 @@ function VersionMessage(arg, options) {
 }
 inherits(VersionMessage, Message);
 
+VersionMessage._name = 'Version';
+
 VersionMessage.prototype.setPayload = function(payload) {
   var parser = new BufferReader(payload);
   this.version = parser.readUInt32LE();

--- a/lib/messages/index.js
+++ b/lib/messages/index.js
@@ -20,7 +20,7 @@ function Messages(options) {
 
   // map message constructors by name
   for(var key in this.builder.commandsMap) {
-    var name = this.builder.commandsMap[key];
+    var name = this.builder.commandsMap[key]._name;
     this[name] = this.builder.commands[key];
   }
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "gulp lint",
-    "test": "gulp test:node",
+    "test": "gulp test",
     "coverage": "gulp coverage",
     "build": "gulp"
   },

--- a/test/messages/commands/index.js
+++ b/test/messages/commands/index.js
@@ -137,7 +137,7 @@ describe('Command Messages', function() {
       var message = messages.FilterLoad();
       var payload = message.getPayload();
       payload.length.should.equal(0);
-      payload.should.be.instanceof(Buffer);
+      Buffer.isBuffer(payload).should.equal(true);
     });
 
     it('should error if filter is not a bloom filter', function() {

--- a/test/messages/index.js
+++ b/test/messages/index.js
@@ -56,7 +56,7 @@ describe('Messages', function() {
   describe('@constructor for all command messages', function() {
     var messages = new Messages();
     Object.keys(messages.builder.commandsMap).forEach(function(command) {
-      var name = messages.builder.commandsMap[command];
+      var name = messages.builder.commandsMap[command]._name;
       it('message.' + name, function(done) {
         should.exist(messages[name]);
         var message = messages[name]();
@@ -70,7 +70,7 @@ describe('Messages', function() {
   describe('#fromBuffer/#toBuffer round trip for all commands', function() {
     var messages = new Messages();
     Object.keys(messages.builder.commandsMap).forEach(function(command) {
-      var name = messages.builder.commandsMap[command];
+      var name = messages.builder.commandsMap[command]._name;
       it(name, function(done) {
         var payloadBuffer = getPayloadBuffer(commandData[command].message);
         should.exist(messages[name]);
@@ -88,7 +88,7 @@ describe('Messages', function() {
   describe('Default Network', function() {
     var messages = new Messages();
     Object.keys(messages.builder.commandsMap).forEach(function(command) {
-      var name = messages.builder.commandsMap[command];
+      var name = messages.builder.commandsMap[command]._name;
       it(name, function() {
         var message = messages[name]();
         message.network.should.deep.equal(bitcore.Networks.defaultNetwork);
@@ -127,7 +127,7 @@ describe('Messages', function() {
 
     describe('#forTransaction', function() {
       constructors.forEach(function(command) {
-        var name = messages.builder.commandsMap[command];
+        var name = messages.builder.commandsMap[command]._name;
         it(name, function() {
           should.exist(messages[name].forTransaction);
           var message = messages[name].forTransaction(fakeHash);
@@ -139,7 +139,7 @@ describe('Messages', function() {
 
     describe('#forBlock', function() {
       constructors.forEach(function(command) {
-        var name = messages.builder.commandsMap[command];
+        var name = messages.builder.commandsMap[command]._name;
         it(name, function() {
           var message = messages[name].forBlock(fakeHash);
           should.exist(message);
@@ -150,7 +150,7 @@ describe('Messages', function() {
 
     describe('#forFilteredBlock', function() {
       constructors.forEach(function(command) {
-        var name = messages.builder.commandsMap[command];
+        var name = messages.builder.commandsMap[command]._name;
         it(name, function() {
           var message = messages[name].forFilteredBlock(fakeHash);
           should.exist(message);

--- a/test/peer.js
+++ b/test/peer.js
@@ -19,15 +19,13 @@ var Messages = P2P.Messages;
 var messages = new Messages();
 var Networks = bitcore.Networks;
 
-// skip these tests in browser
-if (process.browser) {
-  describe = function () {}
-}
+// skip tests in browser
+var bxit = process.browser ? function () {} : it
 
 describe('Peer', function() {
 
   describe('Integration test', function() {
-    it('parses this stream of data from a connection', function(callback) {
+    bxit('parses this stream of data from a connection', function(callback) {
       var peer = new Peer('');
       var stub = sinon.stub();
       var dataCallback;
@@ -76,42 +74,42 @@ describe('Peer', function() {
     });
   });
 
-  it('create instance', function() {
+  bxit('create instance', function() {
     var peer = new Peer('localhost');
     peer.host.should.equal('localhost');
     peer.network.should.equal(Networks.livenet);
     peer.port.should.equal(Networks.livenet.port);
   });
 
-  it('create instance setting a port', function() {
+  bxit('create instance setting a port', function() {
     var peer = new Peer({host: 'localhost', port: 8111});
     peer.host.should.equal('localhost');
     peer.network.should.equal(Networks.livenet);
     peer.port.should.equal(8111);
   });
 
-  it('create instance setting a network', function() {
+  bxit('create instance setting a network', function() {
     var peer = new Peer({host: 'localhost', network: Networks.testnet});
     peer.host.should.equal('localhost');
     peer.network.should.equal(Networks.testnet);
     peer.port.should.equal(Networks.testnet.port);
   });
 
-  it('create instance setting port and network', function() {
+  bxit('create instance setting port and network', function() {
     var peer = new Peer({host: 'localhost', port: 8111, network: Networks.testnet});
     peer.host.should.equal('localhost');
     peer.network.should.equal(Networks.testnet);
     peer.port.should.equal(8111);
   });
 
-  it('create instance without new', function() {
+  bxit('create instance without new', function() {
     var peer = Peer({host: 'localhost', port: 8111, network: Networks.testnet});
     peer.host.should.equal('localhost');
     peer.network.should.equal(Networks.testnet);
     peer.port.should.equal(8111);
   });
 
-  it('set a proxy', function() {
+  bxit('set a proxy', function() {
     var peer, peer2, socket;
 
     peer = new Peer('localhost');
@@ -130,7 +128,7 @@ describe('Peer', function() {
     peer.should.equal(peer2);
   });
 
-  it('send pong on ping', function(done) {
+  bxit('send pong on ping', function(done) {
     var peer = new Peer({host: 'localhost'});
     var pingMessage = messages.Ping();
     peer.sendMessage = function(message) {
@@ -141,7 +139,7 @@ describe('Peer', function() {
     peer.emit('ping', pingMessage);
   });
 
-  it('relay error from socket', function(done) {
+  bxit('relay error from socket', function(done) {
     var peer = new Peer({host: 'localhost'});
     var socket = new EventEmitter();
     socket.connect = sinon.spy();
@@ -158,7 +156,7 @@ describe('Peer', function() {
     peer.socket.emit('error', error);
   });
 
-  it('will not disconnect twice on disconnect and error', function(done) {
+  bxit('will not disconnect twice on disconnect and error', function(done) {
     var peer = new Peer({host: 'localhost'});
     var socket = new EventEmitter();
     socket.connect = sinon.stub();
@@ -178,7 +176,7 @@ describe('Peer', function() {
     peer.socket.emit('error', new Error('fake error'));
   });
 
-  it('disconnect with max buffer length', function(done) {
+  bxit('disconnect with max buffer length', function(done) {
     var peer = new Peer({host: 'localhost'});
     var socket = new EventEmitter();
     socket.connect = sinon.spy();
@@ -194,7 +192,7 @@ describe('Peer', function() {
 
   });
 
-  it('should send version on version if not already sent', function(done) {
+  bxit('should send version on version if not already sent', function(done) {
     var peer = new Peer({host:'localhost'});
     var commands = {};
     peer.sendMessage = function(message) {
@@ -211,7 +209,7 @@ describe('Peer', function() {
     });
   });
 
-  it('should not send version on version if already sent', function(done) {
+  bxit('should not send version on version if already sent', function(done) {
     var peer = new Peer({host:'localhost'});
     peer.versionSent = true;
     var commands = {};
@@ -227,7 +225,7 @@ describe('Peer', function() {
     });
   });
 
-  it('relay set properly', function() {
+  bxit('relay set properly', function() {
     var peer = new Peer({host: 'localhost'});
     peer.relay.should.equal(true);
     var peer2 = new Peer({host: 'localhost', relay: false});
@@ -236,7 +234,7 @@ describe('Peer', function() {
     peer3.relay.should.equal(true);
   });
 
-  it('relay setting respected', function() {
+  bxit('relay setting respected', function() {
     [true,false].forEach(function(relay) {
       var peer = new Peer({host: 'localhost', relay: relay});
       var peerSendMessageStub = sinon.stub(Peer.prototype, 'sendMessage', function(message) {

--- a/test/peer.js
+++ b/test/peer.js
@@ -25,7 +25,7 @@ var bxit = process.browser ? function () {} : it
 describe('Peer', function() {
 
   describe('Integration test', function() {
-    bxit('parses this stream of data from a connection', function(callback) {
+    it('parses this stream of data from a connection', function(callback) {
       var peer = new Peer('');
       var stub = sinon.stub();
       var dataCallback;
@@ -74,35 +74,35 @@ describe('Peer', function() {
     });
   });
 
-  bxit('create instance', function() {
+  it('create instance', function() {
     var peer = new Peer('localhost');
     peer.host.should.equal('localhost');
     peer.network.should.equal(Networks.livenet);
     peer.port.should.equal(Networks.livenet.port);
   });
 
-  bxit('create instance setting a port', function() {
+  it('create instance setting a port', function() {
     var peer = new Peer({host: 'localhost', port: 8111});
     peer.host.should.equal('localhost');
     peer.network.should.equal(Networks.livenet);
     peer.port.should.equal(8111);
   });
 
-  bxit('create instance setting a network', function() {
+  it('create instance setting a network', function() {
     var peer = new Peer({host: 'localhost', network: Networks.testnet});
     peer.host.should.equal('localhost');
     peer.network.should.equal(Networks.testnet);
     peer.port.should.equal(Networks.testnet.port);
   });
 
-  bxit('create instance setting port and network', function() {
+  it('create instance setting port and network', function() {
     var peer = new Peer({host: 'localhost', port: 8111, network: Networks.testnet});
     peer.host.should.equal('localhost');
     peer.network.should.equal(Networks.testnet);
     peer.port.should.equal(8111);
   });
 
-  bxit('create instance without new', function() {
+  it('create instance without new', function() {
     var peer = Peer({host: 'localhost', port: 8111, network: Networks.testnet});
     peer.host.should.equal('localhost');
     peer.network.should.equal(Networks.testnet);
@@ -128,7 +128,7 @@ describe('Peer', function() {
     peer.should.equal(peer2);
   });
 
-  bxit('send pong on ping', function(done) {
+  it('send pong on ping', function(done) {
     var peer = new Peer({host: 'localhost'});
     var pingMessage = messages.Ping();
     peer.sendMessage = function(message) {
@@ -139,7 +139,7 @@ describe('Peer', function() {
     peer.emit('ping', pingMessage);
   });
 
-  bxit('relay error from socket', function(done) {
+  it('relay error from socket', function(done) {
     var peer = new Peer({host: 'localhost'});
     var socket = new EventEmitter();
     socket.connect = sinon.spy();
@@ -156,7 +156,7 @@ describe('Peer', function() {
     peer.socket.emit('error', error);
   });
 
-  bxit('will not disconnect twice on disconnect and error', function(done) {
+  it('will not disconnect twice on disconnect and error', function(done) {
     var peer = new Peer({host: 'localhost'});
     var socket = new EventEmitter();
     socket.connect = sinon.stub();
@@ -192,7 +192,7 @@ describe('Peer', function() {
 
   });
 
-  bxit('should send version on version if not already sent', function(done) {
+  it('should send version on version if not already sent', function(done) {
     var peer = new Peer({host:'localhost'});
     var commands = {};
     peer.sendMessage = function(message) {
@@ -209,7 +209,7 @@ describe('Peer', function() {
     });
   });
 
-  bxit('should not send version on version if already sent', function(done) {
+  it('should not send version on version if already sent', function(done) {
     var peer = new Peer({host:'localhost'});
     peer.versionSent = true;
     var commands = {};
@@ -225,7 +225,7 @@ describe('Peer', function() {
     });
   });
 
-  bxit('relay set properly', function() {
+  it('relay set properly', function() {
     var peer = new Peer({host: 'localhost'});
     peer.relay.should.equal(true);
     var peer2 = new Peer({host: 'localhost', relay: false});
@@ -234,7 +234,7 @@ describe('Peer', function() {
     peer3.relay.should.equal(true);
   });
 
-  bxit('relay setting respected', function() {
+  it('relay setting respected', function() {
     [true,false].forEach(function(relay) {
       var peer = new Peer({host: 'localhost', relay: relay});
       var peerSendMessageStub = sinon.stub(Peer.prototype, 'sendMessage', function(message) {

--- a/test/peer.js
+++ b/test/peer.js
@@ -19,6 +19,11 @@ var Messages = P2P.Messages;
 var messages = new Messages();
 var Networks = bitcore.Networks;
 
+// skip these tests in browser
+if (process.browser) {
+  describe = function () {}
+}
+
 describe('Peer', function() {
 
   describe('Integration test', function() {
@@ -112,7 +117,9 @@ describe('Peer', function() {
     peer = new Peer('localhost');
     expect(peer.proxy).to.be.undefined();
     socket = peer._getSocket();
-    socket.should.be.instanceof(Net.Socket);
+    if (!process.browser) {
+      socket.should.be.instanceof(Net.Socket);
+    }
 
     peer2 = peer.setProxy('127.0.0.1', 9050);
     peer2.proxy.host.should.equal('127.0.0.1');

--- a/test/pool.js
+++ b/test/pool.js
@@ -28,7 +28,7 @@ var bxit = process.browser ? function () {} : it
 
 describe('Pool', function() {
 
-  bxit('create instance', function() {
+  it('create instance', function() {
     var pool = new Pool();
     should.exist(pool.network);
     expect(pool.network).to.satisfy(function(network) {
@@ -36,7 +36,7 @@ describe('Pool', function() {
     });
   });
 
-  bxit('create instance setting the network', function() {
+  it('create instance setting the network', function() {
     var pool = new Pool({network: Networks.testnet});
     pool.network.should.equal(Networks.testnet);
   });
@@ -86,7 +86,7 @@ describe('Pool', function() {
     Peer.prototype.connect.restore();
   });
 
-  bxit('will add addrs via options argument', function() {
+  it('will add addrs via options argument', function() {
     var options = {
       network: Networks.livenet,
       dnsSeed: false,
@@ -102,7 +102,7 @@ describe('Pool', function() {
     pool._addrs.length.should.equal(1);
   });
 
-  bxit('add new addrs as they are announced over the network', function(done) {
+  it('add new addrs as they are announced over the network', function(done) {
 
     // only emit an event, no need to connect
     var peerConnectStub = sinon.stub(Peer.prototype, 'connect', function() {
@@ -153,7 +153,7 @@ describe('Pool', function() {
 
   });
 
-  bxit('can optionally not listen to new addrs messages', function(done) {
+  it('can optionally not listen to new addrs messages', function(done) {
 
     // only emit an event, no need to connect
     var peerConnectStub = sinon.stub(Peer.prototype, 'connect', function() {
@@ -205,7 +205,7 @@ describe('Pool', function() {
 
   });
 
-  bxit('propagate connect, ready, and disconnect peer events', function(done) {
+  it('propagate connect, ready, and disconnect peer events', function(done) {
     var peerConnectStub = sinon.stub(Peer.prototype, 'connect', function() {
       this.emit('connect', this, {});
       this.emit('ready');
@@ -250,7 +250,7 @@ describe('Pool', function() {
     pool.connect();
   });
 
-  bxit('propagate relay property to peers', function(done) {
+  it('propagate relay property to peers', function(done) {
     var count = 0;
     var peerConnectStub = sinon.stub(Peer.prototype, 'connect', function() {
       this.emit('connect', this, {});
@@ -270,7 +270,7 @@ describe('Pool', function() {
     peerConnectStub.restore();
   });
 
-  bxit('output the console correctly', function() {
+  it('output the console correctly', function() {
     var pool = new Pool();
     pool.inspect().should.equal('<Pool network: livenet, connected: 0, available: 0>');
   });
@@ -303,7 +303,7 @@ describe('Pool', function() {
     pool.connect();
   });
 
-  bxit('send message to all peers', function(done) {
+  it('send message to all peers', function(done) {
     var message = 'message';
     sinon.stub(Peer.prototype, 'connect', function() {
       this.socket = {
@@ -339,7 +339,7 @@ describe('Pool', function() {
     pool.connect();
   });
 
-  bxit('not call _fillConnections if keepalive is false on seed', function(done) {
+  it('not call _fillConnections if keepalive is false on seed', function(done) {
     var pool = new Pool({network: Networks.livenet, maxSize: 1});
     pool._fillConnections = sinon.stub();
     pool.keepalive = false;
@@ -352,7 +352,7 @@ describe('Pool', function() {
     pool.emit('seed', []);
   });
 
-  bxit('keep original time for handling peeraddr messages', function(done) {
+  it('keep original time for handling peeraddr messages', function(done) {
     var pool = new Pool({network: Networks.livenet, maxSize: 1});
     var now = new Date();
     pool._addAddr = function(addr) {
@@ -368,7 +368,7 @@ describe('Pool', function() {
     });
   });
 
-  bxit('replace time if time is invalid on peeraddr messages', function(done) {
+  it('replace time if time is invalid on peeraddr messages', function(done) {
     var pool = new Pool({network: Networks.livenet, maxSize: 1});
     var future = new Date(new Date().getTime() + 10 * 70 * 1000);
     var past = new Date(new Date().getTime() - 4 * 24 * 60 * 60 * 1000); // 4 days ago
@@ -387,7 +387,7 @@ describe('Pool', function() {
   });
 
   describe('#_removeConnectedPeer', function() {
-    bxit('disconnect peer if peer status is not disconnected', function(done) {
+    it('disconnect peer if peer status is not disconnected', function(done) {
       var pool = new Pool({network: Networks.livenet, maxSize: 1});
       /* jshint sub: true */
       pool._connectedPeers['hash'] = {
@@ -440,7 +440,7 @@ describe('Pool', function() {
 
   describe('#_addConnectedPeer', function() {
 
-    bxit('should add a peer', function() {
+    it('should add a peer', function() {
       /* jshint sub: true */
       var pool = new Pool({network: Networks.livenet, maxSize: 1});
       pool._addPeerEventHandlers = sinon.stub();
@@ -451,7 +451,7 @@ describe('Pool', function() {
       pool._addPeerEventHandlers.calledOnce.should.equal(true);
     });
 
-    bxit('should not already added peer', function() {
+    it('should not already added peer', function() {
       /* jshint sub: true */
       var pool = new Pool({network: Networks.livenet, maxSize: 1});
       pool._addPeerEventHandlers = sinon.stub();
@@ -463,7 +463,7 @@ describe('Pool', function() {
       pool._addPeerEventHandlers.calledOnce.should.equal(false);
     });
 
-    bxit('will pass network to peer', function() {
+    it('will pass network to peer', function() {
       /* jshint sub: true */
       var pool = new Pool({network: Networks.testnet, maxSize: 1});
       pool._addConnectedPeer({

--- a/test/pool.js
+++ b/test/pool.js
@@ -23,6 +23,11 @@ function getPayloadBuffer(messageBuffer) {
   return new Buffer(messageBuffer.slice(48), 'hex');
 }
 
+// skip these tests in browser
+if (process.browser) {
+  describe = function () {}
+}
+
 describe('Pool', function() {
 
   it('create instance', function() {

--- a/test/pool.js
+++ b/test/pool.js
@@ -23,14 +23,12 @@ function getPayloadBuffer(messageBuffer) {
   return new Buffer(messageBuffer.slice(48), 'hex');
 }
 
-// skip these tests in browser
-if (process.browser) {
-  describe = function () {}
-}
+// skip tests in browser
+var bxit = process.browser ? function () {} : it
 
 describe('Pool', function() {
 
-  it('create instance', function() {
+  bxit('create instance', function() {
     var pool = new Pool();
     should.exist(pool.network);
     expect(pool.network).to.satisfy(function(network) {
@@ -38,12 +36,12 @@ describe('Pool', function() {
     });
   });
 
-  it('create instance setting the network', function() {
+  bxit('create instance setting the network', function() {
     var pool = new Pool({network: Networks.testnet});
     pool.network.should.equal(Networks.testnet);
   });
 
-  it('discover peers via dns', function() {
+  bxit('discover peers via dns', function() {
     var stub = sinon.stub(dns, 'resolve', function(seed, callback) {
       callback(null, ['10.10.10.1', '10.10.10.2', '10.10.10.3']);
     });
@@ -54,7 +52,7 @@ describe('Pool', function() {
     stub.restore();
   });
 
-  it('optionally connect without dns seeds', function() {
+  bxit('optionally connect without dns seeds', function() {
     sinon.stub(Peer.prototype, 'connect', function() {
       this.socket = {
         destroy: sinon.stub()
@@ -88,7 +86,7 @@ describe('Pool', function() {
     Peer.prototype.connect.restore();
   });
 
-  it('will add addrs via options argument', function() {
+  bxit('will add addrs via options argument', function() {
     var options = {
       network: Networks.livenet,
       dnsSeed: false,
@@ -104,7 +102,7 @@ describe('Pool', function() {
     pool._addrs.length.should.equal(1);
   });
 
-  it('add new addrs as they are announced over the network', function(done) {
+  bxit('add new addrs as they are announced over the network', function(done) {
 
     // only emit an event, no need to connect
     var peerConnectStub = sinon.stub(Peer.prototype, 'connect', function() {
@@ -155,7 +153,7 @@ describe('Pool', function() {
 
   });
 
-  it('can optionally not listen to new addrs messages', function(done) {
+  bxit('can optionally not listen to new addrs messages', function(done) {
 
     // only emit an event, no need to connect
     var peerConnectStub = sinon.stub(Peer.prototype, 'connect', function() {
@@ -207,7 +205,7 @@ describe('Pool', function() {
 
   });
 
-  it('propagate connect, ready, and disconnect peer events', function(done) {
+  bxit('propagate connect, ready, and disconnect peer events', function(done) {
     var peerConnectStub = sinon.stub(Peer.prototype, 'connect', function() {
       this.emit('connect', this, {});
       this.emit('ready');
@@ -252,7 +250,7 @@ describe('Pool', function() {
     pool.connect();
   });
 
-  it('propagate relay property to peers', function(done) {
+  bxit('propagate relay property to peers', function(done) {
     var count = 0;
     var peerConnectStub = sinon.stub(Peer.prototype, 'connect', function() {
       this.emit('connect', this, {});
@@ -272,12 +270,12 @@ describe('Pool', function() {
     peerConnectStub.restore();
   });
 
-  it('output the console correctly', function() {
+  bxit('output the console correctly', function() {
     var pool = new Pool();
     pool.inspect().should.equal('<Pool network: livenet, connected: 0, available: 0>');
   });
 
-  it('emit seederrors with error', function(done) {
+  bxit('emit seederrors with error', function(done) {
     var dnsStub = sinon.stub(dns, 'resolve', function(seed, callback) {
       callback(new Error('A DNS error'));
     });
@@ -291,7 +289,7 @@ describe('Pool', function() {
     pool.connect();
   });
 
-  it('emit seederrors with notfound', function(done) {
+  bxit('emit seederrors with notfound', function(done) {
     var dnsStub = sinon.stub(dns, 'resolve', function(seed, callback) {
       callback(null, []);
     });
@@ -305,7 +303,7 @@ describe('Pool', function() {
     pool.connect();
   });
 
-  it('send message to all peers', function(done) {
+  bxit('send message to all peers', function(done) {
     var message = 'message';
     sinon.stub(Peer.prototype, 'connect', function() {
       this.socket = {
@@ -341,7 +339,7 @@ describe('Pool', function() {
     pool.connect();
   });
 
-  it('not call _fillConnections if keepalive is false on seed', function(done) {
+  bxit('not call _fillConnections if keepalive is false on seed', function(done) {
     var pool = new Pool({network: Networks.livenet, maxSize: 1});
     pool._fillConnections = sinon.stub();
     pool.keepalive = false;
@@ -354,7 +352,7 @@ describe('Pool', function() {
     pool.emit('seed', []);
   });
 
-  it('keep original time for handling peeraddr messages', function(done) {
+  bxit('keep original time for handling peeraddr messages', function(done) {
     var pool = new Pool({network: Networks.livenet, maxSize: 1});
     var now = new Date();
     pool._addAddr = function(addr) {
@@ -370,7 +368,7 @@ describe('Pool', function() {
     });
   });
 
-  it('replace time if time is invalid on peeraddr messages', function(done) {
+  bxit('replace time if time is invalid on peeraddr messages', function(done) {
     var pool = new Pool({network: Networks.livenet, maxSize: 1});
     var future = new Date(new Date().getTime() + 10 * 70 * 1000);
     var past = new Date(new Date().getTime() - 4 * 24 * 60 * 60 * 1000); // 4 days ago
@@ -389,7 +387,7 @@ describe('Pool', function() {
   });
 
   describe('#_removeConnectedPeer', function() {
-    it('disconnect peer if peer status is not disconnected', function(done) {
+    bxit('disconnect peer if peer status is not disconnected', function(done) {
       var pool = new Pool({network: Networks.livenet, maxSize: 1});
       /* jshint sub: true */
       pool._connectedPeers['hash'] = {
@@ -405,7 +403,7 @@ describe('Pool', function() {
   });
 
   describe('#_connectPeer', function() {
-    it('connect ipv6 peer', function() {
+    bxit('connect ipv6 peer', function() {
       var connectStub = sinon.stub(Peer.prototype, 'connect');
       var pool = new Pool({network: Networks.livenet, maxSize: 1});
       var ipv6 = '2001:0db8:85a3:0042:1000:8a2e:0370:7334';
@@ -423,7 +421,7 @@ describe('Pool', function() {
       connectStub.restore();
     });
 
-    it('will pass network to peer', function() {
+    bxit('will pass network to peer', function() {
       var connectStub = sinon.stub(Peer.prototype, 'connect');
       var pool = new Pool({network: Networks.testnet, maxSize: 1});
       var ipv6 = '2001:0db8:85a3:0042:1000:8a2e:0370:7334';
@@ -442,7 +440,7 @@ describe('Pool', function() {
 
   describe('#_addConnectedPeer', function() {
 
-    it('should add a peer', function() {
+    bxit('should add a peer', function() {
       /* jshint sub: true */
       var pool = new Pool({network: Networks.livenet, maxSize: 1});
       pool._addPeerEventHandlers = sinon.stub();
@@ -453,7 +451,7 @@ describe('Pool', function() {
       pool._addPeerEventHandlers.calledOnce.should.equal(true);
     });
 
-    it('should not already added peer', function() {
+    bxit('should not already added peer', function() {
       /* jshint sub: true */
       var pool = new Pool({network: Networks.livenet, maxSize: 1});
       pool._addPeerEventHandlers = sinon.stub();
@@ -465,7 +463,7 @@ describe('Pool', function() {
       pool._addPeerEventHandlers.calledOnce.should.equal(false);
     });
 
-    it('will pass network to peer', function() {
+    bxit('will pass network to peer', function() {
       /* jshint sub: true */
       var pool = new Pool({network: Networks.testnet, maxSize: 1});
       pool._addConnectedPeer({
@@ -479,7 +477,7 @@ describe('Pool', function() {
 
   describe('#listen', function() {
 
-    it('create a server', function(done) {
+    bxit('create a server', function(done) {
       var netStub = sinon.stub(net, 'createServer', function() {
         return {
           listen: function() {
@@ -492,7 +490,7 @@ describe('Pool', function() {
       pool.listen();
     });
 
-    it('should handle an ipv6 connection', function(done) {
+    bxit('should handle an ipv6 connection', function(done) {
       var ipv6 = '2001:0db8:85a3:0042:1000:8a2e:0370:7334';
       sinon.stub(net, 'createServer', function(callback) {
         callback({
@@ -517,7 +515,7 @@ describe('Pool', function() {
       pool.listen();
     });
 
-    it('include port for addr on incoming connections', function(done) {
+    bxit('include port for addr on incoming connections', function(done) {
       var port = 12345;
       sinon.stub(net, 'createServer', function(callback) {
         callback({
@@ -539,7 +537,7 @@ describe('Pool', function() {
       pool.listen();
     });
 
-    it('should handle an ipv4 connection', function(done) {
+    bxit('should handle an ipv4 connection', function(done) {
       var ipv4 = '127.0.0.1';
       sinon.stub(net, 'createServer', function(callback) {
         callback({


### PR DESCRIPTION
The procedural `require()`s in `lib/messages/builder.js` were causing problems for Browserify (message building would fail since the constructors were not detected as dependencies and would not be included in the bundle). This PR changes `builder.js` to use an explicit `require()` for each command.

Previously, the builder contained a map of the commands, the values being the names. I changed this so the values are now the `require`d constructors, which each now have a `_name` property.

The tests were also updated to work with this change.