### PR TITLE
include port when adding addr from seed

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -85,7 +85,8 @@ function Pool(options) {
       self._addAddr({
         ip: {
           v4: ip
-        }
+        },
+        port: self.network.port
       });
     });
     if (self.keepalive) {


### PR DESCRIPTION
We were having problems with nodes connecting to other nodes twice: once from the dnsSeed and once from the manually specified addrs array.

This fixes the issue, because when the addr is added from seed, the hash is computed based off both the host and port, the way it should be, preventing duplicate connections from happening.