### PR TITLE
Make addr hash always include port

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -277,6 +277,8 @@ Pool.prototype._deprioritizeAddr = function _deprioritizeAddr(addr) {
  * @param {Object}
  */
 Pool.prototype._addAddr = function _addAddr(addr) {
+  // Use default port if not specified
+  addr.port = addr.port || this.network.port;
 
   // make a unique key
   addr.hash = sha256(new Buffer(addr.ip.v6 + addr.ip.v4 + addr.port)).toString('hex');


### PR DESCRIPTION
We were having problems with nodes connecting to other nodes twice: once from the dnsSeed and once from the manually specified addrs array.

This fixes the issue because if the port was specified in one case, and not the other, the default port will be included in the hash each time, preventing duplicate connections.