### PR TITLE
Fix Bloom filters with vData length >255

### DIFF
--- a/lib/bloomfilter.js
+++ b/lib/bloomfilter.js
@@ -13,7 +13,7 @@ var BufferWriter = bitcore.encoding.BufferWriter;
 BloomFilter.fromBuffer = function fromBuffer(payload) {
   var obj = {};
   var parser = new BufferReader(payload);
-  var length = parser.readUInt8();
+  var length = parser.readVarintNum();
   obj.vData = [];
   for(var i = 0; i < length; i++) {
     obj.vData.push(parser.readUInt8());

--- a/test/bloomfilter.js
+++ b/test/bloomfilter.js
@@ -79,4 +79,10 @@ describe('BloomFilter', function() {
    assert(filter.contains(ParseHex('b9300670b4c5366e95b2699e8b18bc75e5f729c5')));
  });
 
+ it('#toBuffer and #fromBuffer round trip, with a large filter', function() {
+   var filter = BloomFilter.create(10000, 0.001);
+   var buffer = filter.toBuffer();
+   new BloomFilter.fromBuffer(buffer).should.deep.equal(filter);
+ });
+
 });


### PR DESCRIPTION
Currently, the Bloom filter deserialization code assumes the length data segment is a uint8 value, when it should be a varint. This has let the implementation pass the tests and work for small filters, but for filters larger than 255, the code will break.

This PR fixes the problem by using varint length for the Bloom filter deserialzation, and also adds a test for serialization/deserialization of large filters to catch this case.