### PR TITLE
fix broken link in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ peer.on('tx', function(message) {
 });
 ```
 
-Take a look at the [bitcore guide](http://bitcore.io/guide/peer.html) on the usage of the `Peer` class.
+Take a look at the [bitcore guide](http://bitcore.io/guides) for more information.
 
 ## Contributing
 


### PR DESCRIPTION

The link inside the Readme was broken so I fixed it.  There is currently no longer a place in the guide
that describes the Peer so I just fixed the link to point to the Guide.  The other option is to totally
remove the link and the verbiage.  Either option is better than having a broken link, which is the
current situation.