### PR TITLE
Dependency on substack's node-buffers

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "bitcore-lib": "^0.13.7",
     "bloom-filter": "^0.2.0",
-    "buffers": "^0.1.1",
+    "buffers": "bitpay/node-buffers#v0.1.2-bitpay",
     "socks5-client": "^0.3.6"
   },
   "devDependencies": {


### PR DESCRIPTION
- Long-standing deprecation on Array.get has expired, node v6 no longer
supports this.
- Upstream project has not yet merged #17, therefore we must fork and
change this project's dependency.