### PR TITLE
Use bitcore-lib as a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "url": "https://github.com/bitpay/bitcore-p2p.git"
   },
   "dependencies": {
-    "bitcore-lib": "^0.13.7",
     "bloom-filter": "^0.2.0",
     "buffers": "bitpay/node-buffers#v0.1.2-bitpay",
     "socks5-client": "^0.3.6"
@@ -63,6 +62,9 @@
     "chai": "~1.10.0",
     "gulp": "^3.8.10",
     "sinon": "^1.12.2"
+  },
+  "peerDependencies": {
+    "bitcore-lib": "^0.14.0"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
One wrinkle to using the bitcore stack is the obvious need to have a singleton `bitcore-lib`.  The `bitcoin-lib` package hosts the `bitcoind` library and there are good reasons to not wanting to have multiple `bitcoind` instances running on the same machine.

However, I am not a fan of the runtime check and would rather have all packages be declaring `bitcoin-lib` in `peerDependencies`.  This way the enclosing package can specify whatever version of `bitcoin-lib` it wants and `npm` will inform user if there is an unmet dependency at _install_ time rather than _run_ time.

I have a working example of `bitcore-lib` running as a peerDependency at  [bitcore-docker-build](https://github.com/CaptEmulation/bitcore-docker-build) which is also running testnet at [bitcore.soapbubble.online](https://bitcore.soapbubble.online)

I also updated `bitcore-lib` to 0.14 because `bitcore-wallet-service` has already done so and I figured if it was good enough for `bitcoin-wallet-service` it's good enough for everything else :smile: 