### PR TITLE
Unknown command or malformed message should reply with `reject` to peer

### DIFF
--- a/lib/peer.js
+++ b/lib/peer.js
@@ -229,7 +229,18 @@ Peer.prototype._readMessage = function() {
         ccode: this.messages.Reject._constructor.CCODE.REJECT_INVALID,
         reason: 'Unknown command',
       }))
+      return;
     }
+
+    if (error.message.indexOf('Data still available after parsing') !== -1) {
+      this.sendMessage(this.messages.Reject({
+        ccode: this.messages.Reject._constructor.CCODE.REJECT_MALFORMED,
+        reason: 'Malformed payload',
+      }))
+      return;
+    }
+
+    throw error
   }
 };
 

--- a/lib/peer.js
+++ b/lib/peer.js
@@ -228,6 +228,8 @@ Peer.prototype._readMessage = function() {
       this.sendMessage(this.messages.Reject({
         ccode: this.messages.Reject._constructor.CCODE.REJECT_INVALID,
         reason: 'Unknown command',
+        message: 'Unknown command',
+        data: ''
       }));
       return;
     }
@@ -236,6 +238,8 @@ Peer.prototype._readMessage = function() {
       this.sendMessage(this.messages.Reject({
         ccode: this.messages.Reject._constructor.CCODE.REJECT_MALFORMED,
         reason: 'Malformed payload',
+        message: 'Unknown command',
+        data: ''
       }));
       return;
     }

--- a/lib/peer.js
+++ b/lib/peer.js
@@ -217,10 +217,19 @@ Peer.prototype._sendPong = function(nonce) {
  * Internal function that tries to read a message from the data buffer
  */
 Peer.prototype._readMessage = function() {
-  var message = this.messages.parseBuffer(this.dataBuffer);
-  if (message) {
-    this.emit(message.command, message);
-    this._readMessage();
+  try {
+    var message = this.messages.parseBuffer(this.dataBuffer);
+    if (message) {
+      this.emit(message.command, message);
+      this._readMessage();
+    }
+  } catch (error) {
+    if (error.message.indexOf('Unsupported message command:') !== -1) {
+      this.sendMessage(this.messages.Reject({
+        ccode: this.messages.Reject._constructor.CCODE.REJECT_INVALID,
+        reason: 'Unknown command',
+      }))
+    }
   }
 };
 

--- a/lib/peer.js
+++ b/lib/peer.js
@@ -228,7 +228,7 @@ Peer.prototype._readMessage = function() {
       this.sendMessage(this.messages.Reject({
         ccode: this.messages.Reject._constructor.CCODE.REJECT_INVALID,
         reason: 'Unknown command',
-      }))
+      }));
       return;
     }
 
@@ -236,11 +236,11 @@ Peer.prototype._readMessage = function() {
       this.sendMessage(this.messages.Reject({
         ccode: this.messages.Reject._constructor.CCODE.REJECT_MALFORMED,
         reason: 'Malformed payload',
-      }))
+      }));
       return;
     }
 
-    throw error
+    throw error;
   }
 };
 

--- a/test/peer.js
+++ b/test/peer.js
@@ -240,4 +240,20 @@ describe('Peer', function() {
     });
   });
 
+  it('send reject message if invalid command is received', function(done) {
+    var peer = new Peer({host: 'localhost'});
+    peer.sendMessage = function(message) {
+      message.command.should.equal('reject');
+      message.reason.should.equal('Unknown command');
+      message.ccode.should.equal(messages.Reject._constructor.CCODE.REJECT_INVALID);
+      done();
+    };
+    const rawData = 'f9beb4d9' + // bitcoin mainnet magic number
+      '6e6f65786973740000000000' + // command (padded to 16 bytes)
+      '20000000' + // payload length (32)
+      '31085cf0' + // digest - sha256(sha256(payloadBuf)).slice(0,4)
+      '177aace029c59e693bb46cbe028a05ed5b8c4615f7ce590626683e2f56a22b2d'; // payload (random bytes here)
+    peer.dataBuffer.push(new Buffer(rawData, 'hex'));
+    peer._readMessage();
+  });
 });

--- a/test/peer.js
+++ b/test/peer.js
@@ -270,7 +270,8 @@ describe('Peer', function() {
         '70696e670000000000000000' + // command (padded to 16 bytes)
         '20000000' + // payload length (here we declare 32 but actually it is 34)
         '31085cf0' + // digest - sha256(sha256(payloadBuf)).slice(0,4) of the declared payload slice
-        '177aace029c59e693bb46cbe028a05ed5b8c4615f7ce590626683e2f56a22b2d0e'; // payload (random bytes here + added 0e at the end)
+        // payload (random bytes here + added 0e at the end)
+        '177aace029c59e693bb46cbe028a05ed5b8c4615f7ce590626683e2f56a22b2d0e';
       peer.dataBuffer.push(new Buffer(rawData, 'hex'));
       peer._readMessage();
     });


### PR DESCRIPTION
If peer is unable to parse message for specific reasons it should not throw error but reply with a [`reject` message](https://en.bitcoin.it/wiki/Protocol_documentation#reject).

I've stumble upon this in our code, we see exceptions like:
```
2018-05-11T11:47:34.663Z ERROR  <module> Uncaught exception: { stack:
   [ 'Error: Data still available after parsing',
     'at Object.checkFinished (/Users/adam/Work/blockcollider/bcnode/node_modules/bitcore-p2p/lib/messages/utils.js:20:13)',
     'at AddrMessage.setPayload (/Users/adam/Work/blockcollider/bcnode/node_modules/bitcore-p2p/lib/messages/commands/addr.js:48:9)',
     'at Function.exported.commands.(anonymous function).fromBuffer (/Users/adam/Work/blockcollider/bcnode/node_modules/bitcore-p2p/lib/messages/builder.js:75:15)',
     'at Messages._buildFromBuffer (/Users/adam/Work/blockcollider/bcnode/node_modules/bitcore-p2p/lib/messages/index.js:103:41)',
     'at Messages.parseBuffer (/Users/adam/Work/blockcollider/bcnode/node_modules/bitcore-p2p/lib/messages/index.js:74:15)',
     'at Peer._readMessage (/Users/adam/Work/blockcollider/bcnode/node_modules/bitcore-p2p/lib/peer.js:219:31)',
     'at Socket.<anonymous> (/Users/adam/Work/blockcollider/bcnode/node_modules/bitcore-p2p/lib/peer.js:167:10)',
     'at emitOne (events.js:116:13)',
     'at Socket.emit (events.js:211:7)',
     'at addChunk (_stream_readable.js:263:12)' ],
  message: 'Data still available after parsing' }
```

or

```
2018-05-11T11:01:30.571Z ERROR  <module> Uncaught exception: { stack:
   [ 'Error: Unsupported message command: encinit',
     'at Messages._buildFromBuffer (/Users/adam/Work/blockcollider/bcnode/node_modules/bitcore-p2p/lib/messages/index.js:101:11)',
     'at Messages.parseBuffer (/Users/adam/Work/blockcollider/bcnode/node_modules/bitcore-p2p/lib/messages/index.js:74:15)',
     'at Peer._readMessage (/Users/adam/Work/blockcollider/bcnode/node_modules/bitcore-p2p/lib/peer.js:219:31)',
     'at Socket.<anonymous> (/Users/adam/Work/blockcollider/bcnode/node_modules/bitcore-p2p/lib/peer.js:167:10)',
     'at emitOne (events.js:116:13)',
     'at Socket.emit (events.js:211:7)',
     'at addChunk (_stream_readable.js:263:12)',
     'at readableAddChunk (_stream_readable.js:250:11)',
     'at Socket.Readable.push (_stream_readable.js:208:10)',
     'at TCP.onread (net.js:594:20)' ],
  message: 'Unsupported message command: encinit' }
```